### PR TITLE
Guess inverse relationship name if not provided

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.3", "8.2", "8.1", "8.0", "7.4", "7.3" ]
+        php: [ "8.4", "8.3", "8.2", "8.1", "8.0", "7.4", "7.3" ]
 
     name: phpunit (PHP:${{ matrix.php }})
 

--- a/src/HasHasManyWithInverseRelation.php
+++ b/src/HasHasManyWithInverseRelation.php
@@ -2,10 +2,13 @@
 
 namespace Stayallive\Laravel\Eloquent\Relations;
 
+use Illuminate\Support\Str;
+
 trait HasHasManyWithInverseRelation
 {
-    public function hasManyWithInverse($related, $inverse, $foreignKey = null, $localKey = null): HasManyWithInverseRelation
+    public function hasManyWithInverse($related, $inverse = null, $foreignKey = null, $localKey = null): HasManyWithInverseRelation
     {
+        $inverse = $inverse ?: Str::camel(class_basename($this));
         /** @var \Illuminate\Database\Eloquent\Model $this */
         $instance   = $this->newRelatedInstance($related);
         $localKey   = $localKey ?: $this->getKeyName();

--- a/src/HasHasManyWithInverseRelation.php
+++ b/src/HasHasManyWithInverseRelation.php
@@ -8,9 +8,10 @@ trait HasHasManyWithInverseRelation
 {
     public function hasManyWithInverse($related, $inverse = null, $foreignKey = null, $localKey = null): HasManyWithInverseRelation
     {
-        $inverse = $inverse ?: Str::camel(class_basename($this));
         /** @var \Illuminate\Database\Eloquent\Model $this */
-        $instance   = $this->newRelatedInstance($related);
+        $instance = $this->newRelatedInstance($related);
+
+        $inverse    = $inverse ?: Str::camel(class_basename($this));
         $localKey   = $localKey ?: $this->getKeyName();
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 

--- a/src/HasHasOneWithInverseRelation.php
+++ b/src/HasHasOneWithInverseRelation.php
@@ -2,10 +2,13 @@
 
 namespace Stayallive\Laravel\Eloquent\Relations;
 
+use Illuminate\Support\Str;
+
 trait HasHasOneWithInverseRelation
 {
-    public function hasOneWithInverse($related, $inverse, $foreignKey = null, $localKey = null): HasOneWithInverseRelation
+    public function hasOneWithInverse($related, $inverse = null, $foreignKey = null, $localKey = null): HasOneWithInverseRelation
     {
+        $inverse = $inverse ?: Str::camel(class_basename($this));
         /** @var \Illuminate\Database\Eloquent\Model $this */
         $instance   = $this->newRelatedInstance($related);
         $localKey   = $localKey ?: $this->getKeyName();

--- a/src/HasHasOneWithInverseRelation.php
+++ b/src/HasHasOneWithInverseRelation.php
@@ -8,9 +8,10 @@ trait HasHasOneWithInverseRelation
 {
     public function hasOneWithInverse($related, $inverse = null, $foreignKey = null, $localKey = null): HasOneWithInverseRelation
     {
-        $inverse = $inverse ?: Str::camel(class_basename($this));
         /** @var \Illuminate\Database\Eloquent\Model $this */
-        $instance   = $this->newRelatedInstance($related);
+        $instance = $this->newRelatedInstance($related);
+
+        $inverse    = $inverse ?: Str::camel(class_basename($this));
         $localKey   = $localKey ?: $this->getKeyName();
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 

--- a/tests/Stubs/HasManyWithInverse/ChildModel.php
+++ b/tests/Stubs/HasManyWithInverse/ChildModel.php
@@ -16,4 +16,9 @@ class ChildModel extends Model
     {
         return $this->belongsTo(ParentModel::class, 'parent_id');
     }
+
+    public function parentModel(): BelongsTo
+    {
+        return $this->belongsTo(ParentModel::class, 'parent_id');
+    }
 }

--- a/tests/Stubs/HasManyWithInverse/ParentModel.php
+++ b/tests/Stubs/HasManyWithInverse/ParentModel.php
@@ -9,6 +9,7 @@ use Stayallive\Laravel\Eloquent\Relations\HasHasManyWithInverseRelation;
 /**
  * @property int                                      $id
  * @property \Illuminate\Database\Eloquent\Collection $children
+ * @property \Illuminate\Database\Eloquent\Collection $childrenDefaultInverse
  */
 class ParentModel extends Model
 {
@@ -23,5 +24,10 @@ class ParentModel extends Model
     {
         // The `parent` argument (second) is the name of the inverse relationship as defined in the ChildModel
         return $this->hasManyWithInverse(ChildModel::class, 'parent', 'parent_id');
+    }
+
+    public function childrenDefaultInverse(): HasMany
+    {
+        return $this->hasManyWithInverse(ChildModel::class, null, 'parent_id');
     }
 }

--- a/tests/Stubs/HasOneWithInverse/ChildModel.php
+++ b/tests/Stubs/HasOneWithInverse/ChildModel.php
@@ -16,4 +16,9 @@ class ChildModel extends Model
     {
         return $this->belongsTo(ParentModel::class, 'parent_id');
     }
+
+    public function parentModel(): BelongsTo
+    {
+        return $this->belongsTo(ParentModel::class, 'parent_id');
+    }
 }

--- a/tests/Stubs/HasOneWithInverse/ParentModel.php
+++ b/tests/Stubs/HasOneWithInverse/ParentModel.php
@@ -9,6 +9,7 @@ use Stayallive\Laravel\Eloquent\Relations\HasHasOneWithInverseRelation;
 /**
  * @property int                                       $id
  * @property \Tests\Stubs\HasOneWithInverse\ChildModel $child
+ * @property \Tests\Stubs\HasOneWithInverse\ChildModel $childDefaultInverse
  */
 class ParentModel extends Model
 {
@@ -23,5 +24,10 @@ class ParentModel extends Model
     {
         // The `parent` argument (second) is the name of the inverse relationship as defined in the ChildModel
         return $this->hasOneWithInverse(ChildModel::class, 'parent', 'parent_id');
+    }
+
+    public function childDefaultInverse(): HasOne
+    {
+        return $this->hasOneWithInverse(ChildModel::class, null, 'parent_id');
     }
 }

--- a/tests/Unit/HasManyWithInverseTest.php
+++ b/tests/Unit/HasManyWithInverseTest.php
@@ -30,6 +30,17 @@ test('children have the parent relationship automatically set when being created
     expect($child->getRelations()['parent']->id)->toBe($parent->id);
 });
 
+test('parent relationship can be automatically guessed', function () {
+    /** @var \Tests\Stubs\HasManyWithInverse\ParentModel $parent */
+    $parent = ParentModel::create([]);
+
+    /** @var \Tests\Stubs\HasManyWithInverse\ChildModel $child */
+    $child = $parent->childrenDefaultInverse()->create([]);
+
+    expect($child->relationLoaded('parentModel'))->toBeTrue();
+    expect($child->getRelations()['parentModel']->id)->toBe($parent->id);
+});
+
 test('children have the parent relationship automatically set when being created using create many', function () {
     /** @var \Tests\Stubs\HasManyWithInverse\ParentModel $parent */
     $parent = ParentModel::create([]);

--- a/tests/Unit/HasManyWithInverseTest.php
+++ b/tests/Unit/HasManyWithInverseTest.php
@@ -19,6 +19,17 @@ beforeEach(function () {
     });
 });
 
+test('inverse relationship name can be automatically guessed if not provided', function () {
+    /** @var \Tests\Stubs\HasManyWithInverse\ParentModel $parent */
+    $parent = ParentModel::create([]);
+
+    /** @var \Tests\Stubs\HasManyWithInverse\ChildModel $child */
+    $child = $parent->childrenDefaultInverse()->create([]);
+
+    expect($child->relationLoaded('parentModel'))->toBeTrue();
+    expect($child->getRelations()['parentModel']->id)->toBe($parent->id);
+});
+
 test('children have the parent relationship automatically set when being created', function () {
     /** @var \Tests\Stubs\HasManyWithInverse\ParentModel $parent */
     $parent = ParentModel::create([]);
@@ -28,17 +39,6 @@ test('children have the parent relationship automatically set when being created
 
     expect($child->relationLoaded('parent'))->toBeTrue();
     expect($child->getRelations()['parent']->id)->toBe($parent->id);
-});
-
-test('parent relationship can be automatically guessed', function () {
-    /** @var \Tests\Stubs\HasManyWithInverse\ParentModel $parent */
-    $parent = ParentModel::create([]);
-
-    /** @var \Tests\Stubs\HasManyWithInverse\ChildModel $child */
-    $child = $parent->childrenDefaultInverse()->create([]);
-
-    expect($child->relationLoaded('parentModel'))->toBeTrue();
-    expect($child->getRelations()['parentModel']->id)->toBe($parent->id);
 });
 
 test('children have the parent relationship automatically set when being created using create many', function () {

--- a/tests/Unit/HasOneWithInverseTest.php
+++ b/tests/Unit/HasOneWithInverseTest.php
@@ -19,6 +19,17 @@ beforeEach(function () {
     });
 });
 
+test('parent relationship can be automatically guessed', function () {
+    /** @var \Tests\Stubs\HasOneWithInverse\ParentModel $parent */
+    $parent = ParentModel::create([]);
+
+    /** @var \Tests\Stubs\HasOneWithInverse\ChildModel $child */
+    $child = $parent->childDefaultInverse()->create([]);
+
+    expect($child->relationLoaded('parentModel'))->toBeTrue();
+    expect($child->getRelations()['parentModel']->id)->toBe($parent->id);
+});
+
 test('child has the parent relationship automatically set when being created', function () {
     /** @var \Tests\Stubs\HasOneWithInverse\ParentModel $parent */
     $parent = ParentModel::create([]);

--- a/tests/Unit/HasOneWithInverseTest.php
+++ b/tests/Unit/HasOneWithInverseTest.php
@@ -19,7 +19,7 @@ beforeEach(function () {
     });
 });
 
-test('parent relationship can be automatically guessed', function () {
+test('inverse relationship name can be automatically guessed if not provided', function () {
     /** @var \Tests\Stubs\HasOneWithInverse\ParentModel $parent */
     $parent = ParentModel::create([]);
 


### PR DESCRIPTION
This change allows to simplify specifying the inverse relationship - inverse name will be guessed similarly as in Laravel model factories:

https://github.com/laravel/framework/blob/22f4864fcb54cd04fc0e110af193aa9a63905e22/src/Illuminate/Database/Eloquent/Factories/Factory.php#L625-L633